### PR TITLE
Add initial breadcrumb partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [Custom CSS](#custom-css)
   - [Custom JS](#custom-js)
   - [Featured image](#featured-image)
+  - [Breadcrumb](#breadcrumb)
   - [Meta Fields](#meta-fields)
   - [Menus](#menus)
   - [Footer Social Links](#footer-social-links)
@@ -136,6 +137,10 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 [Params.Post]
   meta = ["date"] # Enable post meta fields in given order
 
+[Params.Breadcrumb]
+  enable = true # Enable breadcrumb globally
+  homeText = "Amnix" # Home node text
+
 [Params.Featured]
   previewOnly = false # Show only preview featured image
 
@@ -215,6 +220,7 @@ tags:
   - "Another test"
 
 # Theme-Defined params
+breadcrumb: true # Enable/disable Breadcrumb navigation for specific page
 comments: true # Enable/disable Disqus for specific page
 mathjax: true # Enable/disable MathJax for specific page
 related: true # Enable/disable Related content for specific page
@@ -387,6 +393,25 @@ featured:
 ```
 
 **Note**: `caption` and `credit` appear only on single pages, not summaries.
+
+### Breadcrumb
+
+Breadcrumb navigation is a hierarchical navigation menu presented as a trail of links.
+
+For enabling breadcrumb partial globally (for all single and list pages), use `enable` param under the
+`[Params.Breadcrumb]` section of your config file:
+
+```toml
+[Params.Breadcrumb]
+  enable = true
+```
+
+The global `.Site.Params.Breadcrumb.enable` param can be overridden for specific page with `breadcrumb` front matter
+param:
+
+```yaml
+breadcrumb: false
+```
 
 ### Meta Fields
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -279,9 +279,18 @@ th {
 .single {
 	display: flex;
 	flex: 1 0;
-	flex-wrap: wrap;
+	flex-direction: column;
 	order: 1;
 	min-width: 0;
+}
+
+.postbox {
+	display: flex;
+	flex-basis: auto;
+	flex-shrink: 0;
+	flex-grow: 1;
+	flex-wrap: wrap;
+	order: 1;
 }
 
 .post {
@@ -328,6 +337,36 @@ th {
 	flex-direction: column;
 	width: 100%;
 	margin: 0;
+}
+
+.breadcrumb {
+	padding: .5rem 1rem;
+	margin: .25rem .25rem -.25rem;
+	color: #666;
+	border-width: 1px 1px 0;
+}
+
+.breadcrumb--separated {
+	margin: .25rem;
+	border-width: 1px;
+}
+
+.breadcrumb__list {
+	display: flex;
+	flex-wrap: wrap;
+	padding: 0;
+	margin: 0;
+	list-style: none;
+}
+
+.breadcrumb__item {
+	display: flex;
+}
+
+.breadcrumb__item::after {
+	display: block;
+	margin: 0 .3125rem;
+	content: "›";
 }
 
 .post__featured {

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,5 +1,6 @@
 {{ define "main" }}
 	<div class="content">
+		{{ partial "breadcrumb.html" . }}
 		{{ if or .Title .Content }}
 		<section class="taxonomy">
 			{{ with .Title }}<h1 class="taxonomy__title">{{ . }}</h1>{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,20 +1,23 @@
 {{ define "main" }}
 	<section class="single">
-		<article class="post block">
-			{{- partial "post/post_featured.html" (dict "page" . "IsSingle" true) }}
-			<header class="post__header">
-				<h1 class="post__title">{{ .Title }}</h1>
-				{{ partial "post/post_meta.html" . }}
-			</header>
-			<div class="post__content">{{ .Content }}</div>
-			{{ if or (.Param "share") (isset $.Params "tags") }}
-			<footer class="post__footer">
-				{{ partial "post/post_tags.html" . }}
-				{{ partial "post/post_share.html" . }}
-			</footer>
-			{{ end }}
-		</article>
-		{{ partial "related.html" . }}
-		{{ partial "comments.html" . }}
+		{{ partial "breadcrumb.html" . }}
+		<div class="postbox">
+			<article class="post block">
+				{{- partial "post/post_featured.html" (dict "page" . "IsSingle" true) }}
+				<header class="post__header">
+					<h1 class="post__title">{{ .Title }}</h1>
+					{{ partial "post/post_meta.html" . }}
+				</header>
+				<div class="post__content">{{ .Content }}</div>
+				{{ if or (.Param "share") (isset $.Params "tags") }}
+				<footer class="post__footer">
+					{{ partial "post/post_tags.html" . }}
+					{{ partial "post/post_share.html" . }}
+				</footer>
+				{{ end }}
+			</article>
+			{{ partial "related.html" . }}
+			{{ partial "comments.html" . }}
+		</div>
 	</section>
 {{ end }}

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,0 +1,31 @@
+{{- $breadcrumb := default .Site.Params.Breadcrumb.enable .Params.breadcrumb -}}
+
+{{- define "breadcrumbnav" }}
+	{{- if .p1.Parent -}}
+		{{- template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2) -}}
+	{{- else if not .p1.IsHome }}
+		{{- template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2) -}}
+	{{- end }}
+
+	{{- $crumbTitle := .p1.Title | default "..." -}}
+	{{- $crumbTitleHome := .p1.Site.Params.Breadcrumb.homeText | default .p1.Site.Title -}}
+	{{- if .p1.IsHome -}}
+		{{- $crumbTitle = $crumbTitleHome -}}
+	{{- end -}}
+
+	{{- if ne .p1 .p2 }}
+		<li class="breadcrumb__item">
+			<a class="breadcrumbs__link" href="{{ .p1.RelPermalink }}">{{ $crumbTitle }}</a>
+		</li>
+	{{- else }}
+		<li class="breadcrumbs__item breadcrumb__item--active" aria-current="page">{{ $crumbTitle }}</li>
+	{{- end }}
+{{- end }}
+
+{{- if $breadcrumb }}
+<nav class="breadcrumb{{ if not (or $.Title $.Content) }} breadcrumb--separated{{ end }} block" aria-label="breadcrumb">
+	<ol class="breadcrumb__list">
+		{{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
+	</ol>
+</nav>
+{{- end }}


### PR DESCRIPTION
This PR adds initial breadcrumb support.

**Screenshot:**

![breadcrumb](https://user-images.githubusercontent.com/21033483/69652943-6c59d780-1040-11ea-9c58-7d0deff755ab.png)

**Changelog:**

* Add initial breadcrumb partial
* Add aria-current=page property
* Add separators via CSS to be comply with screen readers
* Use ordered list to the set of links
* Update README.md: add breadcrumb section
