### PR TITLE
CI: fix verbose option for Hugo ≥0.114.0

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -63,4 +63,6 @@ jobs:
           HUGO_VERSION=$(hugo version | grep -Eo '[0-9]\.[0-9]+\.[0-9]+')
           # The option changed in 0.93.0: https://github.com/gohugoio/hugo/releases/tag/v0.93.0
           I18N_OPT=$([ $(ver $HUGO_VERSION) -lt $(ver 0.93.0) ] && echo "--i18n-warnings" || echo "--printI18nWarnings")
-          HUGO_THEME="Amnix" hugo --themesDir ../.. $I18N_OPT -v
+          # The option deprecated in v0.114.0 (WARNs >= 0.120.0): https://github.com/gohugoio/hugo/releases/tag/v0.114.0
+          LOG_OPT=$([ $(ver $HUGO_VERSION) -lt $(ver 0.114.0) ] && echo "--verbose" || echo "--logLevel info")
+          HUGO_THEME="Amnix" hugo --themesDir ../.. $I18N_OPT $LOG_OPT


### PR DESCRIPTION
This PR fixes the verbose option for Hugo ≥0.114.0 in our CI. Almost the same as before with the `--i18n-warnings` option.

From Hugo v0.114.0 `--verbose` option has been deprecated in favor of `--logLevel info`. Deprecated option causes
warning since v0.120.0 